### PR TITLE
Added new filter flags and options for export in PCAP format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ options are:
  -i         # dump header info in file
  -d         # dump data in file
  -h         # print help and usage
+ -o filename # export output to PCAP file
+ -s ip_src   # filter packets by IP source
+ -t ip_dst   # filter packets by IP destination
+ -p port_src # filter packets by source port
+               will filter TCP and UDP only
+ -q port_src # filter packets by destination port
+               will filter TCP and UDP only
+ -l ttl_min  # filter packets by minimun TTL
+ -m ttl_max  # filter packets by maximum TTL
+ -f frag_min # filter packets by minimum fragment number
+ -g frag_max # filter packets by maximun fragment number
 ```
 
 With option -i, you can capture incoming traffic and log ip/udp/tcp/icmp headers in file. If you add option -d, sCap will capture headers and also it will hexdump incoming traffic data in log file. Without those arguments, sCap only counts numbers of incoming packets.

--- a/src/info.c
+++ b/src/info.c
@@ -44,10 +44,21 @@ void greet(char *p_name)
  */
 void usage(char *fname)
 {
-    printf("\nUsage: %s [-i] [-d] [-h]\n", fname);
+    printf("\nUsage: %s [options]\n", fname);
     printf("Options are:\n");
     printf("   -i         # dump header info in file\n");
     printf("   -d         # dump data in file\n");
     printf("   -h         # print help and usage\n");
+    printf("   -o filename # export output to PCAP file\n");
+    printf("   -s ip_src   # filter packets by IP source\n");
+    printf("   -t ip_dst   # filter packets by IP destination\n");
+    printf("   -p port_src # filter packets by source port\n");
+    printf("                 will filter TCP and UDP only\n");
+    printf("   -q port_src # filter packets by destination port\n");
+    printf("                 will filter TCP and UDP only\n");
+    printf("   -l ttl_min  # filter packets by minimun TTL\n");
+    printf("   -m ttl_max  # filter packets by maximum TTL\n");
+    printf("   -f frag_min # filter packets by minimum fragment number\n");
+    printf("   -g frag_max # filter packets by maximun fragment number\n");
     printf("\n");
 }


### PR DESCRIPTION
For an work in my university I choosed to add funcionalities to Scap.

The funcionalities I have added are:
- Option to export the captured packets in PCAP format. You can open a PCAP file in Wireshark.
- Some filters that can be enabled by flags:
  - Filter by protocol (tcp, udp, icmp, etc)
  - Filter by source ip and destination ip
  - Filter by source port and destination port
  - Filter by min and max TTL
  - Filter by min and max fragment number

I'm making this pull request to contribute with what I have made.

Thanks for doing this program, I learned a lot hacking it.
